### PR TITLE
Make it work!

### DIFF
--- a/MauiApp1/MauiProgram.cs
+++ b/MauiApp1/MauiProgram.cs
@@ -3,8 +3,22 @@ using MauiApp1.Data;
 using ZXing.Net.Maui;
 using ZXing;
 using ZXing.Net.Maui.Readers;
+#if __ANDROID__
+using Android.Webkit;
+#endif
 
 namespace MauiApp1;
+
+#if __ANDROID__
+
+public class MyChrome : Android.Webkit.WebChromeClient
+{
+    public override void OnPermissionRequest(PermissionRequest request)
+    {
+        request.Grant(request.GetResources());
+    }
+}
+#endif
 
 public static class MauiProgram
 {
@@ -13,6 +27,16 @@ public static class MauiProgram
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()
+			.ConfigureMauiHandlers(handlers =>
+			{
+				// Gerald: This was added
+				BlazorWebViewHandler.BlazorWebViewMapper.AppendToMapping("EnablePermissions", (handler, webview) =>
+				{
+#if __ANDROID__
+				    handler.PlatformView.SetWebChromeClient(new MyChrome());
+#endif
+				});
+			})
 			.ConfigureFonts(fonts =>
 			{
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");


### PR DESCRIPTION
This creates a custom WebChromeClient that will automatically accept any permissions request. When using .NET MAUI Blazor you will have to accept the permissions for the web view as well as the native app. This auto-accepts all permissions for the web view.